### PR TITLE
Error in getNextKey method

### DIFF
--- a/src/main/java/guru/springframework/services/AbstractMapService.java
+++ b/src/main/java/guru/springframework/services/AbstractMapService.java
@@ -41,6 +41,8 @@ public abstract class AbstractMapService  {
     }
 
     private Integer getNextKey(){
+        if(domainMap.size()==0)
+            return 1;
         return Collections.max(domainMap.keySet()) + 1;
     }
 


### PR DESCRIPTION
We get an error here because at the beginning domainMap is empty.
Hence the Collections.max() method returns null.

We have to handle the initial case separately.